### PR TITLE
Fix compilation without OpenMP

### DIFF
--- a/gtfold-mfe/include/partition-func-d2.h
+++ b/gtfold-mfe/include/partition-func-d2.h
@@ -102,7 +102,9 @@ class PartitionFunctionD2{
 #include "algorithms-partition.h"
 #include "global.h"
 #include "utils.h"
+#ifdef _OPENMP
 #include<omp.h>
+#endif
 #include <assert.h>
 #define MEMORY_OPTIMIZATION_ENABLED false
 #define PAIRABLE_POINTS_GATHER_OPTIMIZATION_DISABLED true

--- a/gtfold-mfe/include/stochastic-sampling-d2.h
+++ b/gtfold-mfe/include/stochastic-sampling-d2.h
@@ -825,7 +825,11 @@ double StochasticTracebackD2<MyDouble>::rnd_structure_parallel(int* structure, i
 			//#pragma omp parallel for private(index) shared(energy_threads, g_stack_threads, structure) schedule(guided)
 			#endif
 			for (index = 0; index < (int)g_deque.size(); ++index) {
-				int thdId = omp_get_thread_num();
+                                #ifdef _OPENMP
+                                int thdId = omp_get_thread_num();
+                                #else
+                                int thdId = 0;
+                                #endif
 				base_pair bp = g_deque[index];
 				if (bp.type() == U)
 					rnd_u(bp.i,bp.j, structure, energy_threads[thdId], g_stack_threads[thdId]);
@@ -1241,7 +1245,11 @@ void StochasticTracebackD2<MyDouble>::batch_sample_parallel(int num_rnd, bool ST
 		for (count = 1; count <= num_rnd; ++count) 
 		{
 			//nsamples++;
+                        #ifdef _OPENMP
 			int thdId = omp_get_thread_num();
+                        #else
+                        int thdId = 0;
+                        #endif
 			countArr[thdId]++;
 			//cout<<"thdId="<<thdId<<endl;
 			int* structure = structures_thread + thdId*(length+1);

--- a/gtfold-mfe/include/stochastic-sampling-d2.h
+++ b/gtfold-mfe/include/stochastic-sampling-d2.h
@@ -135,7 +135,9 @@ public:
 #include<sstream>
 #include<fstream>
 #include "utils.h"
+#ifdef _OPENMP
 #include<omp.h>
+#endif
 #include<time.h>
 #include<unistd.h>
 

--- a/gtfold-mfe/src/partition-func.c
+++ b/gtfold-mfe/src/partition-func.c
@@ -357,7 +357,11 @@ void fill_partition_arrays()
 {
 	int b,i,j;
 	int n=part_len;
-	int numThds = omp_get_num_threads();
+        #ifdef _OPENMP
+        int numThds = omp_get_num_threads();
+        #else
+        int numThds = 1;
+        #endif
 	int* i_canPair = (int*)malloc((n+1)*sizeof(int));
 	int* i_cannotPair = (int*)malloc((n+1)*sizeof(int));
 	int len_i_canPair=0, len_i_cannotPair=0;


### PR DESCRIPTION
The --disable-openmp option to the compile script produces source that won't build. With these changes, it builds and runs, but someone who actually knows C++ should check to make sure I've done it correctly.
fixes #121 
