### PR TITLE
Explicitly initialize energy in eMUnpairedRegion

### DIFF
--- a/rna-scoring/LoopScoring.c
+++ b/rna-scoring/LoopScoring.c
@@ -12,7 +12,7 @@ int eMUnpairedRegion(int i1, int j1, int i2, int j2, int* RNA, nndb_constants* p
 	//(based on Andronescu masters thesis,
 	// M.Sc., Academy of Economic Studies, Bucharest, Romania, 2000, 
 	// pg 32.)
-	int energy;
+	int energy = 0;
 	/*
 	int PFMODE=0;//boltzman sampling or stochastic sampling and  partition function mode or dS mode, it is mode as defined and used for partition function of sfold
 	int NODANGLEMODE=0;//no dangling at all means d0


### PR DESCRIPTION
The eMUnpairedRegion() method of RNAScoring does not initialize the value of `energy`. There is a path through the conditionals in this method where `energy` is never set (the case when `j1+1<i2-1` and `D2MODE=0`)—and this path is in fact used in the code! Thus, it is possible for an essentially random value of `energy` to make it out. I don't know enough about the science to say what the correct value of `energy` is in this case, so this patch just initializes `energy` to 0. 
