### PR TITLE
Fix bogus h bounds in WMPrime loop

### DIFF
--- a/gtfold-mfe/src/algorithms.c
+++ b/gtfold-mfe/src/algorithms.c
@@ -189,7 +189,7 @@ int calculate(int len) {
 
       // Added auxillary storage WMPrime to speedup multiloop calculations
       int h;
-      for (h = i+TURN+1 ; h <= j-TURN-2; h++) {
+      for (h = i+TURN+1 ; h <= j-TURN; h++) {
         WMPrime[i][j] = MIN(WMPrime[i][j], WMU(i,h-1) + WML(h,j)); 
       }
 


### PR DESCRIPTION
In the computation of the WMPrime auxillary array, the index variable h is used differently than in Andronescu's thesis, rendering the used bounds incorrect. I have test cases where the current code gives the wrong energy which are fixed by this revision.
